### PR TITLE
Fixed content.yaml file, array is named artifacts + add info in logs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 target/
+.idea/

--- a/rust/sogar/Cargo.lock
+++ b/rust/sogar/Cargo.lock
@@ -1613,7 +1613,7 @@ dependencies = [
 
 [[package]]
 name = "sogar-core"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "clap",
  "config",

--- a/rust/sogar/sogar-core/Cargo.toml
+++ b/rust/sogar/sogar-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sogar-core"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Anastasiia Romaniuk <romaniuk.anastasiia@apriorit.com>"]
 edition = "2018"
 description = "Simple OCI Generic Artifact Registry (SOGAR)"


### PR DESCRIPTION
1 - I fixed the content.yaml file content

The content.yaml file was something like this : 
```
blobs: 
  84190ded607550bc7dc39f435b82a02722ccb2a21ac6d0dbd3a9e1f730eae559: video/webm
  d38bc9c7-fa34-4575-9c13-fa8720954ef8: application/vnd.oci.image.manifest.v1+json
```

and it was deserialized in that struct
```
#[derive(Deserialize)]
struct ArtifactsData {
    artifacts: HashMap<String, String>,
}
```
It failed. I fixed that.

2 - I added a trace if you try to read a content file that doesn't exist.
3 - I bumped the version to 0.1.1